### PR TITLE
Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: ruby
 
 bundler_args: --without development
 
+cache:
+  bundler: true
+
 services:
   - docker
 

--- a/libraries/database.rb
+++ b/libraries/database.rb
@@ -1,0 +1,28 @@
+module MysqlResources
+  module Database
+    def connect_database(&block)
+      MysqlResources::Database.connect(new_resource.host,
+                                       new_resource.admin_user,
+                                       new_resource.admin_password,
+                                       'mysql',
+                                       new_resource.connector,
+                                       &block)
+    end
+
+    class << self
+      attr_accessor :database
+
+      def connect(host, username, password, db = 'mysql', connector = 'mysql')
+        connector == 'mysql' ? 'mysql' : 'mysql2'
+        require connector
+        require 'sequel'
+        MysqlResources::Database.database ||= {}
+        MysqlResources::Database.database[connector] ||= {}
+        MysqlResources::Database.database[connector][host] ||= {}
+        conn = MysqlResources::Database.database[connector][host][username] ||= Sequel.connect("#{connector}://#{username}:#{password}@#{host}/#{db}")
+        yield conn if block_given?
+        conn
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'marc.millien@gmail.com'
 license 'all_rights'
 description 'Installs/Configures mysql resources'
 long_description 'Installs and configures mysql users, databases and user rights'
-version '0.1.4'
+version '0.1.1'
 
 issues_url 'https://github.com/marcmillien/mysql-resources-chef-cookbook/issues'
 source_url 'https://github.com/marcmillien/mysql-resources-chef-cookbook'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'marc.millien@gmail.com'
 license 'all_rights'
 description 'Installs/Configures mysql resources'
 long_description 'Installs and configures mysql users, databases and user rights'
-version '0.1.0'
+version '0.1.4'
 
 issues_url 'https://github.com/marcmillien/mysql-resources-chef-cookbook/issues'
 source_url 'https://github.com/marcmillien/mysql-resources-chef-cookbook'

--- a/resources/mysql_database.rb
+++ b/resources/mysql_database.rb
@@ -11,20 +11,28 @@ default_action :create
 
 action_class do
   def connect_database
-    require 'mysql'
+    require 'mysql2'
     require 'sequel'
 
-    Sequel.connect(
-      "mysql://#{new_resource.admin_user}:#{new_resource.admin_password}@#{new_resource.host}/mysql"
+    conn = Sequel.connect(
+      "mysql2://#{new_resource.admin_user}:#{new_resource.admin_password}@#{new_resource.host}/mysql"
     )
+    
+    return conn unless block_given?
+    yield conn
+    conn.close
   end
 
   def create_database
-    connect_database.execute("CREATE DATABASE IF NOT EXISTS #{new_resource.dbname}")
+    connect_database do |db|
+      db.execute("CREATE DATABASE IF NOT EXISTS #{new_resource.dbname}")
+    end
   end
 
   def drop_database
-    connect_database.execute("DROP DATABASE IF EXISTS #{new_resource.dbname}")
+    connect_database do |db|
+      db.execute("DROP DATABASE IF EXISTS #{new_resource.dbname}")
+    end
   end
 end
 

--- a/resources/mysql_database.rb
+++ b/resources/mysql_database.rb
@@ -5,23 +5,13 @@ property :dbname, String, name_property: true
 property :host, String, name_property: false, required: true
 property :admin_user, String, name_property: false, required: true
 property :admin_password, String, name_property: false, required: true
+property :connector, String, default: 'mysql', desired_state: false
 
 actions :create, :delete
 default_action :create
 
 action_class do
-  def connect_database
-    require 'mysql2'
-    require 'sequel'
-
-    conn = Sequel.connect(
-      "mysql2://#{new_resource.admin_user}:#{new_resource.admin_password}@#{new_resource.host}/mysql"
-    )
-    
-    return conn unless block_given?
-    yield conn
-    conn.close
-  end
+  include MysqlResources::Database
 
   def create_database
     connect_database do |db|

--- a/resources/mysql_user.rb
+++ b/resources/mysql_user.rb
@@ -12,38 +12,73 @@ default_action :create
 
 action_class do
   def connect_database
-    require 'mysql'
+    require 'mysql2'
     require 'sequel'
 
-    Sequel.connect(
-      "mysql://#{new_resource.admin_user}:#{new_resource.admin_password}@#{new_resource.host}/mysql"
+    conn = Sequel.connect(
+      "mysql2://#{new_resource.admin_user}:#{new_resource.admin_password}@#{new_resource.host}/mysql"
     )
+    return conn unless block_given?
+    
+    yield conn
+    conn.close
   end
 
   def exist_user?
     u = new_resource.user.split('@')
     size = 0
-    connect_database[
-      "SELECT COUNT(*) AS number FROM mysql.user WHERE user='#{u[0]}' AND host='#{u[1]}'"
-    ].each do |row|
-      size = row[:number]
+    connect_database do |db|
+      db[
+        "SELECT COUNT(*) AS number FROM mysql.user WHERE user='#{u[0]}' AND host='#{u[1]}'"
+      ].each do |row|
+        size = row[:number]
+      end
     end
     size > 0
   end
 
+  def changed_password?
+    u = new_resource.user.split('@')
+    changed = false
+    connect_database do |db|
+      db[
+        "SELECT password AS current_password, PASSWORD('#{new_resource.password}') AS new_password FROM mysql.user WHERE user='#{u[0]}' AND host='#{u[1]}'"
+      ].each do |row|
+        changed = row[:current_password] || row[:new_password]
+      end
+    end
+    changed
+  end
+  
+  def update_user
+    return unless changed_password?
+    u = new_resource.user.split('@')
+    connect_database do |db|
+      db.execute("set password for '#{u[0]}'@'#{u[1]}' = PASSWORD('#{new_resource.password}')")
+    end
+  end
+  
   def create_user
     u = new_resource.user.split('@')
-    connect_database.execute("CREATE USER '#{u[0]}'@'#{u[1]}' IDENTIFIED BY '#{new_resource.password}'")
+    connect_database do |db|
+      db.execute("CREATE USER '#{u[0]}'@'#{u[1]}' IDENTIFIED BY '#{new_resource.password}'")
+    end
   end
 
   def drop_user
     u = new_resource.user.split('@')
-    connect_database.execute("DROP USER '#{u[0]}'@'#{u[1]}")
+    connect_database do |db|
+      db.execute("DROP USER '#{u[0]}'@'#{u[1]}'")
+    end
   end
 end
 
 action :create do
-  create_user unless exist_user?
+  if exist_user?
+    update_user
+  else
+    create_user
+  end
 end
 
 action :delete do


### PR DESCRIPTION
This allows the resource to make use of the mysql2 connector by setting connector 'mysql2' in any of the resources (as mysql gem is out of support)

Notable other changes:

mysql_grant now has a toggleable 'with_grant' setting that appends 'with grant option' to the grant call

mysql_user now maintains the password if changed

Sequel.connect has been refactored so that the calling code yields a block. It has also been refactored so that it does not call connect on each resource: When calling multiple mysql_resources in a cookbook, you can easily exhaust the connection pool size.

