### PR TITLE
Added support for CentOS and Debian stretch

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,19 +1,27 @@
 ---
-driver:
-  name: docker
-
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.19
+  require_chef_omnibus: true
 
 platforms:
   - name: debian-docker-jessie
+    driver:
+      name: docker
     driver_config:
-      binary: /usr/bin/docker
       image: debian:jessie
-      username: admin
       platform: debian
-      use_sudo: false
+  - name: debian-docker-stretch
+    driver:
+      name: docker
+    driver_config:
+      image: debian:stretch
+      platform: debian
+  - name: centos-7.2
+    driver:
+      name: vagrant
+  - name: centos-7.5
+    driver:
+      name: vagrant
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Manage mysql databases, users and grants from chef.
 - Chef 12.19
 - Network accessible package repositories
 
-## Plateform support
+## Platform support
 
-- Debian jessie (8) only tested
+- Tested on Debian jessie (8), Debian stretch (9), CentOS 7.2 & 7.5
 
 ## Usage
 

--- a/recipes/_test.rb
+++ b/recipes/_test.rb
@@ -1,4 +1,18 @@
-package 'mysql-server'
+case node['platform_family']
+when 'debian'
+  package 'mysql-server'
+  service 'mysql' do
+    action :start
+  end
+  ENV['MYSQL_UNIX_PORT'] = '/run/mysqld/mysqld.sock'
+when 'rhel'
+  yum_package 'mariadb-server'
+  service 'mariadb' do
+    action :start
+  end
+  ENV['MYSQL_UNIX_PORT'] = '/var/lib/mysql/mysql.sock'
+end
+
 bash 'change_root_password' do
   code 'mysqladmin -u root password password'
   ignore_failure true
@@ -6,8 +20,9 @@ bash 'change_root_password' do
   retry_delay 5
 end
 
-service 'mysql' do
-  action :start
+bash 'enable_root_password' do
+  code 'mysql -u root mysql -e "UPDATE user SET plugin=\'mysql_native_password\' WHERE user=\'root\'; FLUSH PRIVILEGES;"'
+  ignore_failure true
 end
 
 mysql_database 'somedb' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,17 +1,22 @@
-apt_package %w(
-  mysql-client
-  ruby
-  ruby-all-dev
-  build-essential
-  libmysqlclient-dev
-)
+if node['platform_family'] == 'debian'
 
-chef_gem 'mysql' do
+  apt_package %w(
+    mysql-client
+    ruby
+    ruby-all-dev
+    build-essential
+  )
+
+  apt_package node['lsb']['codename'] == 'jessie' ? 'libmysqlclient-dev' : 'default-libmysqlclient-dev'
+
+end
+
+chef_gem 'ruby-mysql' do
   compile_time false
-  version '2.9.1'
+  version '2.9.14'
 end
 
 chef_gem 'sequel' do
   compile_time false
-  version '4.44.0'
+  version '5.10.0'
 end

--- a/resources/mysql_database.rb
+++ b/resources/mysql_database.rb
@@ -27,7 +27,6 @@ action_class do
 end
 
 action :create do
-  package 'ruby-mysql'
   create_database
 end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 
-describe package 'mysql-client' do
-  it { should be_installed }
+if os[:family] == 'debian'
+  describe package 'mysql-client' do
+    it { should be_installed }
+  end
 end
 
 describe command('/opt/chef/embedded/bin/gem list') do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/^mysql \(2\.9\.[0-9]+\)$/) }
-  its(:stdout) { should match(/^sequel \(4\.44\.[0-9]+\)$/) }
+  its(:stdout) { should match(/^ruby-mysql \(2\.9\.[0-9]+\)$/) }
+  its(:stdout) { should match(/^sequel \(5\.10\.[0-9]+\)$/) }
 end
 
 describe command('echo "SHOW DATABASES" | mysql -uroot -ppassword') do


### PR DESCRIPTION
Added support for CentOS and Debian stretch. Also use 'ruby-mysql' gem instead of 'mysql' as the latter is no longer maintained.